### PR TITLE
Use a class again

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -32,8 +32,7 @@
     "valid-typeof": 2
   },
   "env": {
-    "es6": true,
-    "browser": true
+    "es6": true
   },
   "parser": "babel-eslint",
   "extends": "eslint:recommended",

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-Push client helpers
-===================
+Propel
+======
 
 > A library to support developers implementing Web Push notifications
 
 Support
 -------
 
-If you’ve found an error in this library, please file an issue: https://github.com/GoogleChrome/push-client-helper/issues
+If you’ve found an error in this library, please file an issue: https://github.com/GoogleChrome/Propel/issues
 
 Patches are encouraged, and may be submitted by forking this project and submitting a pull request through GitHub.
 

--- a/src/client.js
+++ b/src/client.js
@@ -148,6 +148,20 @@ let pushClient = {
     navigator.serviceWorker.removeEventListener('message', messageHandler);
   },
 
+  async getSubscription() {
+    if (!this.supported()) {
+      return;
+    }
+
+    let registration = await getRegistration();
+
+    if (!registration) {
+      return;
+    }
+
+    return await registration.pushManager.getSubscription();
+  },
+
   supported() {
     return SUPPORTED;
   },

--- a/src/client.js
+++ b/src/client.js
@@ -10,6 +10,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
+/* eslint-env browser */
 
 import SubscriptionFailedError from './client/subscription-failed-error';
 

--- a/src/client.js
+++ b/src/client.js
@@ -99,7 +99,10 @@ let pushClient = {
       // POST subscription details
       await fetch(endpoint, {
         method: 'post',
-        body: JSON.stringify(sub),
+        body: JSON.stringify({
+          action: 'subscribe',
+          subscription: sub
+        }),
         headers: {
           'Content-Type': 'application/json'
         }
@@ -109,7 +112,7 @@ let pushClient = {
     return sub;
   },
 
-  async unsubscribe() {
+  async unsubscribe({endpoint=null} = {}) {
     if (!this.supported()) {
       return;
     }
@@ -124,6 +127,20 @@ let pushClient = {
 
     if (subscription) {
       await subscription.unsubscribe();
+
+      if (endpoint) {
+        // POST subscription details
+        await fetch(endpoint, {
+          method: 'post',
+          body: JSON.stringify({
+            action: 'unsubscribe',
+            subscription: subscription
+          }),
+          headers: {
+            'Content-Type': 'application/json'
+          }
+        });
+      }
     }
 
     await registration.unregister();

--- a/src/client/endpoint.js
+++ b/src/client/endpoint.js
@@ -1,0 +1,29 @@
+/*
+  Copyright 2015 Google Inc. All Rights Reserved.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+/* eslint-env browser */
+
+export default class Endpoint {
+  constructor(url) {
+    this.url = url;
+  }
+
+  send(message) {
+    return fetch(this.url, {
+      method: 'post',
+      body: JSON.stringify(message),
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    });
+  }
+}

--- a/src/worker.js
+++ b/src/worker.js
@@ -14,6 +14,10 @@
 
 'use strict';
 
+self.addEventListener('install', function(event) {
+  self.skipWaiting();
+});
+
 self.addEventListener('notificationclick', function(event) {
   event.waitUntil(event.notification.close());
 });

--- a/src/worker.js
+++ b/src/worker.js
@@ -10,3 +10,4 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
+/* eslint-env serviceworker */

--- a/src/worker.js
+++ b/src/worker.js
@@ -11,3 +11,38 @@
   limitations under the License.
 */
 /* eslint-env serviceworker */
+
+'use strict';
+
+self.addEventListener('notificationclick', function(event) {
+  event.waitUntil(event.notification.close());
+});
+
+let pushWorker = {
+  async getClientWindows({visibleOnly=false, url=null} = {}) {
+    try {
+      let windows = clients.matchAll({
+        type: 'window',
+        includeUncontrolled: true
+      });
+
+      if (url) {
+        windows = windows.filter((c) => c.url === url);
+      }
+
+      if (visibleOnly) {
+        windows =
+            windows.filter((c) => c.focused && c.visibilityState === 'visible');
+      }
+
+      return windows;
+    } catch (error) {
+      // Couldn't get client list, possibly not yet implemented in the browser
+      return [];
+    }
+  }
+};
+
+self.goog = self.goog || {};
+self.goog.push = self.goog.push || {};
+self.goog.push.worker = pushWorker;


### PR DESCRIPTION
(Depends on #1, so includes those commits too)

So, after thinking about it, I'm back with the class. I know, I know!

It makes sense now because we actually ship the class not just an instance. Usage is now:

```javascript
let pushClient = new goog.propel.Client({endpoint: '/my-push-endpoint'});

pushClient.subscribe();
pushClient.unsubscribe();
```

This means that we only set the endpoint URL once rather than passing it every time. Also let's us have other options globally.

R: @ithinkihaveacat @gauntface 