### PR TITLE
Adding first set up tests - very simple

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,15 @@
     "babelify": "^6.3.0",
     "browserify": "^11.2.0",
     "browserify-header": "^0.9.2",
+    "chai": "^3.4.1",
+    "express": "^4.13.3",
     "gulp": "^3.9.0",
     "gulp-eslint": "^1.0.0",
+    "mocha": "^2.3.4",
     "vinyl-source-stream": "^1.1.0"
   },
   "license": "Apache-2.0",
   "scripts": {
-    "test" : "gulp lint"
+    "test": "gulp lint"
   }
 }

--- a/test/browser-tests/push-client/push-client-tests.js
+++ b/test/browser-tests/push-client/push-client-tests.js
@@ -85,12 +85,4 @@ describe('Test PushClient', () => {
       window.chai.expect(pushClient.workerUrl).to.contain('/sw.js');
     });
   });
-
-  describe('Test PushClient API Surface', () => {
-    it('should be able to call supported on a push client', () => {
-      var pushClient = new window.goog.propel.Client();
-      window.chai.expect(pushClient).to.have.property('subscribe');
-      window.chai.expect(pushClient).to.have.property('unsubscribe');
-    });
-  });
 });

--- a/test/browser-tests/push-client/push-client-tests.js
+++ b/test/browser-tests/push-client/push-client-tests.js
@@ -91,8 +91,6 @@ describe('Test PushClient', () => {
       var pushClient = new window.goog.propel.Client();
       window.chai.expect(pushClient).to.have.property('subscribe');
       window.chai.expect(pushClient).to.have.property('unsubscribe');
-      window.chai.expect(pushClient).to.have.property('supported');
-      window.chai.expect(pushClient).to.have.property('hasPermission');
     });
   });
 });

--- a/test/browser-tests/push-client/push-client-tests.js
+++ b/test/browser-tests/push-client/push-client-tests.js
@@ -1,0 +1,98 @@
+/*
+  Copyright 2016 Google Inc. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+// This is a test and we want descriptions to be useful, if this
+// breaks the max-length, it's ok.
+
+/* eslint-disable max-len, no-unused-expressions */
+/* eslint-env browser, mocha */
+/* global testHelper */
+
+'use strict';
+
+describe('Test PushClient', () => {
+  it('should be able to find window.goog.propel.Client', function() {
+    window.goog.propel.Client.should.be.defined;
+  });
+
+  describe('Test PushClient construction', () => {
+    it('should be able to create a new push client', function() {
+      var pushClient = new window.goog.propel.Client();
+      window.chai.expect(pushClient.endpoint).to.eql(null);
+      window.chai.expect(pushClient.userId).to.equal(null);
+      window.chai.expect(pushClient.workerUrl).to.contain('dist/worker.js');
+    });
+
+    it('should be able to create a new push client with an empty object', function() {
+      var pushClient = new window.goog.propel.Client({});
+
+      window.chai.expect(pushClient.endpoint).to.eql(null);
+      window.chai.expect(pushClient.userId).to.equal(null);
+      window.chai.expect(pushClient.workerUrl).to.contain('dist/worker.js');
+    });
+
+    it('should be able to create a new push client with additional options', function() {
+      var pushClient = new window.goog.propel.Client({
+        endpointUrl: null,
+        userId: null,
+        workerUrl: '/sw.js'
+      });
+      window.chai.expect(pushClient.endpoint).to.eql(null);
+      window.chai.expect(pushClient.userId).to.equal(null);
+      window.chai.expect(pushClient.workerUrl).to.equal('/sw.js');
+    });
+
+    it('should be able to create a new push client with just endpoint option', function() {
+      var pushClient = new window.goog.propel.Client({
+        endpointUrl: null
+      });
+
+      window.chai.expect(pushClient.endpoint).to.eql(null);
+      window.chai.expect(pushClient.userId).to.equal(null);
+      window.chai.expect(pushClient.workerUrl).to.contain('dist/worker.js');
+    });
+
+    it('should be able to create a new push client with just userId option', function() {
+      var pushClient = new window.goog.propel.Client({
+        userId: null
+      });
+
+      window.chai.expect(pushClient.endpoint).to.eql(null);
+      window.chai.expect(pushClient.userId).to.equal(null);
+      window.chai.expect(pushClient.workerUrl).to.contain('dist/worker.js');
+    });
+
+    it('should be able to create a new push client with just workerUrl option', function() {
+      var pushClient = new window.goog.propel.Client({
+        workerUrl: '/sw.js'
+      });
+
+      window.chai.expect(pushClient.endpoint).to.eql(null);
+      window.chai.expect(pushClient.userId).to.equal(null);
+      window.chai.expect(pushClient.workerUrl).to.contain('/sw.js');
+    });
+  });
+
+  describe('Test PushClient API Surface', () => {
+    it('should be able to call supported on a push client', () => {
+      var pushClient = new window.goog.propel.Client();
+      window.chai.expect(pushClient).to.have.property('subscribe');
+      window.chai.expect(pushClient).to.have.property('unsubscribe');
+      window.chai.expect(pushClient).to.have.property('supported');
+      window.chai.expect(pushClient).to.have.property('hasPermission');
+    });
+  });
+});

--- a/test/index.html
+++ b/test/index.html
@@ -38,14 +38,9 @@
 
   <!-- Push Client Code We Will Test -->
   <script src="/dist/client.js"></script>
-
-  <!--
-    Timeout is extended to ensure tests for max-cache-age
-    have enough time to complete
-  -->
+  
   <script>mocha.setup({
-    ui: 'bdd',
-    timeout: 5000
+    ui: 'bdd'
   })</script>
 
   <!-- In browser test scripts should be added to the page here-->
@@ -56,7 +51,7 @@
       // To automate the tests with selenium, we need a way
       // to inform selenium when the tests are completed and
       // pass results back.
-      // This is done by waiting for window.swtoolbox to be defined.
+      // This is done by waiting for window.testsuite to be defined.
       // This is done in publishTestResults();
       var passedTests = [];
       var failedTests = [];
@@ -71,24 +66,14 @@
       };
 
       // Once this is called, automated tests should be
-      // able to read sw.toolbox and get test results.
+      // able to read window.testsuite and get test results.
       function publishTestResults() {
-        window.swtoolbox = {
+        window.testsuite = {
           testResults: {
             passed: passedTests,
             failed: failedTests
           }
         };
-      }
-
-      // This make browsers without a service worker pass tests by
-      // bypassing the tests altogether.
-      // This is desirable to allow travis to run tests in all browsers
-      // regardless of support or not and perform tests when the browser
-      // starts to support service workers.
-      if (!('serviceWorker' in navigator)) {
-        publishTestResults();
-        return;
       }
 
       // should adds objects to primitives which requires this call to be made

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,124 @@
+<!--
+  Copyright 2016 Google Inc. All rights reserved.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Propel Tests</title>
+  <link href="/node_modules/mocha/mocha.css" rel="stylesheet" />
+
+  <!--
+    iframes are used to manage service worker scoping.
+    This will hide them and stop the page from jumping around
+  -->
+  <style>
+    iframe {
+      width: 0;
+      height: 0;
+    }
+  </style>
+</head>
+<body>
+  <div id="mocha"></div>
+
+  <script src="/node_modules/chai/chai.js"></script>
+  <script src="/node_modules/mocha/mocha.js"></script>
+
+  <!-- Helper functions will be under window.testHelper -->
+  <script src="/test/libs/helper-functions.js"></script>
+
+  <!-- Push Client Code We Will Test -->
+  <script src="/dist/client.js"></script>
+
+  <!--
+    Timeout is extended to ensure tests for max-cache-age
+    have enough time to complete
+  -->
+  <script>mocha.setup({
+    ui: 'bdd',
+    timeout: 5000
+  })</script>
+
+  <!-- In browser test scripts should be added to the page here-->
+  <script src="/test/browser-tests/push-client/push-client-tests.js"></script>
+
+  <script>
+    (function() {
+      // To automate the tests with selenium, we need a way
+      // to inform selenium when the tests are completed and
+      // pass results back.
+      // This is done by waiting for window.swtoolbox to be defined.
+      // This is done in publishTestResults();
+      var passedTests = [];
+      var failedTests = [];
+
+      // This is a helper method that simplifies the test
+      // results to an object that can be JSON.string-ified.
+      function getFriendlyTestResult(testResult) {
+        return {
+          title: testResult.title,
+          state: testResult.state
+        };
+      };
+
+      // Once this is called, automated tests should be
+      // able to read sw.toolbox and get test results.
+      function publishTestResults() {
+        window.swtoolbox = {
+          testResults: {
+            passed: passedTests,
+            failed: failedTests
+          }
+        };
+      }
+
+      // This make browsers without a service worker pass tests by
+      // bypassing the tests altogether.
+      // This is desirable to allow travis to run tests in all browsers
+      // regardless of support or not and perform tests when the browser
+      // starts to support service workers.
+      if (!('serviceWorker' in navigator)) {
+        publishTestResults();
+        return;
+      }
+
+      // should adds objects to primitives which requires this call to be made
+      // before any tests are run.
+      window.chai.should();
+
+      // We unregister all service workers, clear all caches and remove
+      // All registered iframes
+      beforeEach(function() {
+        return testHelper.cleanState();
+      });
+
+      // Clean up after the final test has finished
+      after(function() {
+        return testHelper.cleanState();
+      });
+
+      var runResults = mocha.run();
+      // pass, fail and end events allow up to capture results and
+      // determine when to publish test results
+      runResults.on('pass', function(test) {
+        passedTests.push(getFriendlyTestResult(test));
+      })
+      .on('fail', function(test) {
+        failedTests.push(getFriendlyTestResult(test));
+      })
+      .on('end', function() {
+        publishTestResults();
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/test/libs/helper-functions.js
+++ b/test/libs/helper-functions.js
@@ -1,0 +1,185 @@
+/**
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/* eslint-env browser */
+
+var testCounter = 0;
+
+window.testHelper = {
+  // Each service worker that is registered should be given a unique
+  // scope. To achieve this we register it with a scope the same as
+  // an iframe's src that is unique for each test.
+  // Service workers will then be made to claim pages on this scope -
+  // i.e. the iframe
+  getIframe: function() {
+    return new Promise(resolve => {
+      var existingIframe = document.querySelector('.js-test-iframe');
+      if (existingIframe) {
+        return resolve(existingIframe);
+      }
+
+      // This will be used as a unique service worker scope
+      testCounter++;
+
+      var newIframe = document.createElement('iframe');
+      newIframe.classList.add('js-test-iframe');
+      newIframe.src = '/test/iframe/' + testCounter;
+      newIframe.addEventListener('load', () => {
+        resolve(newIframe);
+      });
+      document.body.appendChild(newIframe);
+    });
+  },
+
+  unregisterAllRegistrations: function() {
+    return navigator.serviceWorker.getRegistrations()
+      .then(registrations => {
+        return Promise.all(registrations.map(registration => {
+          registration.unregister();
+        }));
+      });
+  },
+
+  clearAllCaches: function() {
+    return window.caches.keys()
+      .then(cacheNames => {
+        return Promise.all(cacheNames.map(cacheName => {
+          window.caches.delete(cacheName);
+        }));
+      });
+  },
+
+  // Waiting for a service worker to install is handy if you only care
+  // about testing events that have occured in the install event
+  installSW: function(swUrl) {
+    return new Promise((resolve, reject) => {
+      var iframe;
+      this.getIframe()
+      .then(newIframe => {
+        var options = null;
+        if (newIframe) {
+          options = {scope: iframe.contentWindow.location.pathname};
+          iframe = newIframe;
+        }
+
+        return navigator.serviceWorker.register(swUrl, options);
+      })
+      .then(registration => {
+        if (registration.installing === null) {
+          throw new Error(swUrl + ' already installed.');
+        }
+
+        // We unregister all service workers after each test - this should
+        // always trigger an install state change
+        registration.installing.onstatechange = function() {
+          if (this.state !== 'installed') {
+            return;
+          }
+
+          resolve(iframe);
+        };
+      })
+      .catch(err => {
+        reject(err);
+      });
+    });
+  },
+
+  // To test fetch event behaviour in a service worker you will need to wait
+  // for the service worker to activate
+  activateSW: function(swUrl) {
+    return new Promise((resolve, reject) => {
+      var iframe;
+      this.getIframe()
+      .then(newIframe => {
+        var options = null;
+        if (newIframe) {
+          options = {scope: newIframe.contentWindow.location.pathname};
+          iframe = newIframe;
+        }
+        return navigator.serviceWorker.register(swUrl, options);
+      })
+      .then(registration => {
+        if (registration.installing === null) {
+          throw new Error(swUrl + ' already installed.');
+        }
+
+        // We unregister all service workers after each test - so this should
+        // always have an activate event if the service worker calls
+        // self.clients.claim()
+        registration.installing.onstatechange = function() {
+          if (this.state !== 'activated') {
+            return;
+          }
+
+          resolve(iframe);
+        };
+      })
+      .catch(err => {
+        reject(err);
+      });
+    });
+  },
+
+  // This is a helper method that checks the cache exists before
+  // getting all the cached responses.
+  // This is limited to text at the moment.
+  getAllCachedAssets: function(cacheName) {
+    var cache = null;
+    return window.caches.has(cacheName)
+      .then(hasCache => {
+        if (!hasCache) {
+          throw new Error('Cache doesn\'t exist.');
+        }
+
+        return window.caches.open(cacheName);
+      })
+      .then(openedCache => {
+        cache = openedCache;
+        return cache.keys();
+      })
+      .then(cacheKeys => {
+        return Promise.all(cacheKeys.map(cacheKey => {
+          return cache.match(cacheKey);
+        }));
+      })
+      .then(cacheResponses => {
+        // This method extracts the response streams and pairs
+        // them with a url.
+        var output = {};
+        cacheResponses.map(response => {
+          output[response.url] = response;
+        });
+        return output;
+      });
+  },
+
+  // Helper to unregister all service workers and clean all caches
+  // This should be called before each test
+  cleanState: function() {
+    return Promise.all([
+      this.unregisterAllRegistrations(),
+      this.clearAllCaches()
+    ])
+    .then(() => {
+      var iframeList = document.querySelectorAll('.js-test-iframe');
+      for (var i = 0; i < iframeList.length; i++) {
+        iframeList[i].parentElement.removeChild(iframeList[i]);
+      }
+    });
+  }
+};

--- a/test/libs/helper-functions.js
+++ b/test/libs/helper-functions.js
@@ -17,34 +17,7 @@
 
 /* eslint-env browser */
 
-var testCounter = 0;
-
 window.testHelper = {
-  // Each service worker that is registered should be given a unique
-  // scope. To achieve this we register it with a scope the same as
-  // an iframe's src that is unique for each test.
-  // Service workers will then be made to claim pages on this scope -
-  // i.e. the iframe
-  getIframe: function() {
-    return new Promise(resolve => {
-      var existingIframe = document.querySelector('.js-test-iframe');
-      if (existingIframe) {
-        return resolve(existingIframe);
-      }
-
-      // This will be used as a unique service worker scope
-      testCounter++;
-
-      var newIframe = document.createElement('iframe');
-      newIframe.classList.add('js-test-iframe');
-      newIframe.src = '/test/iframe/' + testCounter;
-      newIframe.addEventListener('load', () => {
-        resolve(newIframe);
-      });
-      document.body.appendChild(newIframe);
-    });
-  },
-
   unregisterAllRegistrations: function() {
     return navigator.serviceWorker.getRegistrations()
       .then(registrations => {
@@ -60,111 +33,6 @@ window.testHelper = {
         return Promise.all(cacheNames.map(cacheName => {
           window.caches.delete(cacheName);
         }));
-      });
-  },
-
-  // Waiting for a service worker to install is handy if you only care
-  // about testing events that have occured in the install event
-  installSW: function(swUrl) {
-    return new Promise((resolve, reject) => {
-      var iframe;
-      this.getIframe()
-      .then(newIframe => {
-        var options = null;
-        if (newIframe) {
-          options = {scope: iframe.contentWindow.location.pathname};
-          iframe = newIframe;
-        }
-
-        return navigator.serviceWorker.register(swUrl, options);
-      })
-      .then(registration => {
-        if (registration.installing === null) {
-          throw new Error(swUrl + ' already installed.');
-        }
-
-        // We unregister all service workers after each test - this should
-        // always trigger an install state change
-        registration.installing.onstatechange = function() {
-          if (this.state !== 'installed') {
-            return;
-          }
-
-          resolve(iframe);
-        };
-      })
-      .catch(err => {
-        reject(err);
-      });
-    });
-  },
-
-  // To test fetch event behaviour in a service worker you will need to wait
-  // for the service worker to activate
-  activateSW: function(swUrl) {
-    return new Promise((resolve, reject) => {
-      var iframe;
-      this.getIframe()
-      .then(newIframe => {
-        var options = null;
-        if (newIframe) {
-          options = {scope: newIframe.contentWindow.location.pathname};
-          iframe = newIframe;
-        }
-        return navigator.serviceWorker.register(swUrl, options);
-      })
-      .then(registration => {
-        if (registration.installing === null) {
-          throw new Error(swUrl + ' already installed.');
-        }
-
-        // We unregister all service workers after each test - so this should
-        // always have an activate event if the service worker calls
-        // self.clients.claim()
-        registration.installing.onstatechange = function() {
-          if (this.state !== 'activated') {
-            return;
-          }
-
-          resolve(iframe);
-        };
-      })
-      .catch(err => {
-        reject(err);
-      });
-    });
-  },
-
-  // This is a helper method that checks the cache exists before
-  // getting all the cached responses.
-  // This is limited to text at the moment.
-  getAllCachedAssets: function(cacheName) {
-    var cache = null;
-    return window.caches.has(cacheName)
-      .then(hasCache => {
-        if (!hasCache) {
-          throw new Error('Cache doesn\'t exist.');
-        }
-
-        return window.caches.open(cacheName);
-      })
-      .then(openedCache => {
-        cache = openedCache;
-        return cache.keys();
-      })
-      .then(cacheKeys => {
-        return Promise.all(cacheKeys.map(cacheKey => {
-          return cache.match(cacheKey);
-        }));
-      })
-      .then(cacheResponses => {
-        // This method extracts the response streams and pairs
-        // them with a url.
-        var output = {};
-        cacheResponses.map(response => {
-          output[response.url] = response;
-        });
-        return output;
       });
   },
 

--- a/test/server/index.js
+++ b/test/server/index.js
@@ -19,15 +19,12 @@
 
 /* eslint-env node */
 
-// This server is needed most importantly to add the Service-Worker-Allowed
-// header to any service worker loaded in the tests. This allows the scope
-// to be manipulated any way we want / need during testing.
-
 var path = require('path');
 var express = require('express');
 var app = express();
 
-// Set up static assets
+// Set up static assets and add service worker allowed header in case it's
+// needed for registering SW during tests
 app.use('/test/browser-tests/',
   express.static(path.join(__dirname, '..', 'browser-tests/'), {
     setHeaders: function(res) {
@@ -36,7 +33,8 @@ app.use('/test/browser-tests/',
   })
 );
 
-// Allow all assets in the project to be served (This includes sw-toolbox.js)
+// Allow all assets in the project to be served, including any
+// required js code from the project
 app.use('/', express.static(path.join(__dirname, '..', '..')));
 
 // If the user tries to go to the root of the test server, redirect them

--- a/test/server/index.js
+++ b/test/server/index.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+'use strict';
+
+/* eslint-env node */
+
+// This server is needed most importantly to add the Service-Worker-Allowed
+// header to any service worker loaded in the tests. This allows the scope
+// to be manipulated any way we want / need during testing.
+
+var path = require('path');
+var express = require('express');
+var app = express();
+
+// Set up static assets
+app.use('/test/browser-tests/',
+  express.static(path.join(__dirname, '..', 'browser-tests/'), {
+    setHeaders: function(res) {
+      res.setHeader('Service-Worker-Allowed', '/');
+    }
+  })
+);
+
+// Allow all assets in the project to be served (This includes sw-toolbox.js)
+app.use('/', express.static(path.join(__dirname, '..', '..')));
+
+// If the user tries to go to the root of the test server, redirect them
+// to /test/
+app.get('/', function(req, res) {
+  res.redirect('/test/');
+});
+
+// Start service on port 8888
+var server = app.listen(8888, function() {
+  console.log('Example app listening at http://localhost:%s',
+    server.address().port);
+});


### PR DESCRIPTION
These tests are just for the constructor and looking at API surface. May change when it comes to testing with Service Workers.

These current tests fail for:

  var pushClient = new window.goog.propel.Client();
  pushClient.supported();
  pushClient.hasPermission();

This is because those methods are static, you would have to do something along the lines of PushClient.supported() or in this case: window.goog.propel.Client.supported().