### PR TITLE
Docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+docs

--- a/esdoc.json
+++ b/esdoc.json
@@ -1,0 +1,9 @@
+{
+  "source": "./src",
+  "destination": "./docs",
+  "includes": ["\\.(js|es6)$"],
+  "autoPrivate": true,
+  "plugins": [
+    {"name": "esdoc-es7-plugin"}
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "browserify": "^11.2.0",
     "browserify-header": "^0.9.2",
     "chai": "^3.4.1",
+    "esdoc-es7-plugin": "0.0.3",
     "express": "^4.13.3",
     "gulp": "^3.9.0",
     "gulp-eslint": "^1.0.0",

--- a/src/client/push-client.js
+++ b/src/client/push-client.js
@@ -228,13 +228,10 @@ export default class PushClient extends EventDispatch {
   }
 
   /**
-   * If a service worker is registered for push, this method will return a
-   * promise that will resolve with the registration for that service worker.
-   *
-   * If there is no registration null will be the resolved reponse.
+   * Get the registration of the service worker being used for push.
    *
    * @return {Promise<ServiceWorkerRegistration>} A Promise that
-   *  resolves with a ServiceWorkerRegistration or null.
+   *  resolves to either a ServiceWorkerRegistration or to null if none.
    */
   async getRegistration() {
     let reg = await navigator.serviceWorker.getRegistration(this._scope);

--- a/src/client/push-client.js
+++ b/src/client/push-client.js
@@ -65,7 +65,27 @@ let registrationReady = function(registration) {
   });
 };
 
+/**
+ * PushClient is a front end library that simplifies adding push to your
+ * site.
+ */
 export default class PushClient {
+  /**
+   * Constructs a new PushClient.
+   *
+   * If the current browser has a push scription then it will be
+   * obtained in the constructor and sent to the endpointUrl if supplied
+   * and a subscriptionChange event will be dispatched.
+   *
+   * @param {Object} [options] - Options object should be included if you
+   *  want to define any of the following.
+   * @param {String} [options.endpointUrl] - If supplied this endpoint will be
+   *  sent a POST request containing the users PushSubscription object.
+   * @param {String} [options.userId] - If an endpointUrl is defined the
+   *  userId will be passed with the request to that endpoint.
+   * @param {String} [options.workerUrl] - Service worker URL to be
+   *  registered that will receive push events.
+   */
   constructor({endpointUrl=null, userId=null, workerUrl=WORKER_URL,
       scope=SCOPE} = {}) {
     if (!PushClient.supported()) {
@@ -96,6 +116,18 @@ export default class PushClient {
     }
   }
 
+  /**
+   * This method will subscribe a use for push messaging.
+   *
+   * If permission isn't granted for push, this method will show the
+   * permissions dialog before attempting to subscribe the user to push.
+   *
+   * If an endpointUrl is supplied to the constructor, this will recieve
+   * a subscribe event.
+   *
+   * @return {Promise<PushSubscription>} Returns a Promise that
+   *  resolves with a PushSubscription if successful.
+   */
   async subscribe() {
     // Check for permission
     let permission = await requestPermission();
@@ -138,6 +170,16 @@ export default class PushClient {
     return sub;
   }
 
+  /**
+   * This method will unsubscribe the user from push on the client side.
+   *
+   * If you supplied an endpoint, this method will call it with an
+   * unsubscribe event, including the origin subscription object as well
+   * as the userId if supplied.
+   *
+   * @return {Promise} Returns a Promise that
+   *  resolves once the user is unsubscribed.
+   */
   async unsubscribe() {
     let registration = await this.getRegistration();
     let subscription;
@@ -160,6 +202,15 @@ export default class PushClient {
     }
   }
 
+  /**
+   * If a service worker is registered for push, this method will return a
+   * promise that will resolve with the registration for that service worker.
+   *
+   * If there is no registration null will be the resolved reponse.
+   *
+   * @return {Promise<ServiceWorkerRegistration>} Returns a Promise that
+   *  resolves with a ServiceWorkerRegistration or null.
+   */
   async getRegistration() {
     let reg = await navigator.serviceWorker.getRegistration(this.scope);
 
@@ -168,6 +219,15 @@ export default class PushClient {
     }
   }
 
+  /**
+   * If the user is currently subscribed for push then the returned promise will
+   * resolve with a PushSubscription object, otherwise it will resolve to null.
+   *
+   * This will not display the permission dialog.
+   *
+   * @return {Promise<PushSubscription>} Returns a Promise that resolves with
+   *  a PushSubscription or null.
+   */
   async getSubscription() {
     let registration = await this.getRegistration();
 
@@ -178,10 +238,21 @@ export default class PushClient {
     return registration.pushManager.getSubscription();
   }
 
+  /**
+   * You can use this to decide whether to construct a new PushClient or not.
+   * @return {Boolean} Whether the current browser has everything needed
+   *  to use push messaging.
+   */
   static supported() {
     return SUPPORTED;
   }
 
+  /**
+   * This method can be used to check if subscribing the user will display
+   * the permission dialog or not.
+   * @return {Boolean} Returns true if you have permission to subscribe
+   *  the user for push messages.
+   */
   static hasPermission() {
     return Notification.permission === 'granted';
   }


### PR DESCRIPTION
@wibblymat 

First crack at adding some docs.

Build them with: esdoc -c esdoc.json  

This uses esdoc with  "esdoc-es7-plugin" to work with the async and await stuff (which blocked us from using jsdoc).

Generally the output seems ok and it has ability to add a manual should we want it.

If this seems ok, I'm happy scrap this PR and just focus on automating deploying to github pages (or something similar) OR we can take this PR, everyone work on improving current comments and I'll still add the github pages stuff ASAP.

I've only looked at the PushClient.js to see what kind of output we'd get. Only thing that we might want to change code wise is with variables like this.endpoint, this.scope etc are all treated as public in the docs, we can make then private with comments:

    /**
     * @private
     */

Or we can make the variable names start with _ and then it's treated as private.