### PR TITLE
Remove the endpoint code from the main client, make it an optional extra

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -13,7 +13,10 @@
 /* eslint-env browser */
 
 import PushClient from './client/push-client';
+import serverUpdater from './client/server-updater';
 
 window.goog = window.goog || {};
-window.goog.propel = window.goog.propel || {};
-window.goog.propel.Client = PushClient;
+window.goog.propel = window.goog.propel || {
+  Client: PushClient,
+  serverUpdater: serverUpdater
+};

--- a/src/client/push-client.js
+++ b/src/client/push-client.js
@@ -13,7 +13,6 @@
 /* eslint-env browser */
 
 import SubscriptionFailedError from './subscription-failed-error';
-import Endpoint from './endpoint';
 import PushClientEvent from './push-client-event';
 import EventDispatch from './event-dispatch';
 
@@ -76,28 +75,23 @@ export default class PushClient extends EventDispatch {
    * Constructs a new PushClient.
    *
    * If the current browser has a push subscription then it will be
-   * obtained in the constructor and sent to the endpointUrl if supplied
-   * and a subscriptionChange event will be dispatched.
+   * obtained in the constructor and a subscriptionChange event will be
+   * dispatched.
    *
    * @param {Object} options - Options object should be included if you
    *  want to define any of the following.
-   * @param {String} options.endpointUrl - If supplied this endpoint will be
-   *  sent a POST request containing the users PushSubscription object.
-   * @param {String} options.userId - If an endpointUrl is defined the
-   *  userId will be passed with the request to that endpoint.
    * @param {String} options.workerUrl - Service worker URL to be
    *  registered that will receive push events.
+   * @param {String} options.scope - The scope that the Service worker should be
+   *  registered with.
    */
-  constructor({endpointUrl=null, userId=null, workerUrl=WORKER_URL,
-      scope=SCOPE} = {}) {
+  constructor({workerUrl=WORKER_URL, scope=SCOPE} = {}) {
     super();
 
     if (!PushClient.supported()) {
       throw new Error('Your browser does not support the web push API');
     }
 
-    this._endpoint = endpointUrl ? new Endpoint(endpointUrl) : null;
-    this._userId = userId;
     this._workerUrl = workerUrl;
     this._scope = scope;
 
@@ -121,14 +115,6 @@ export default class PushClient extends EventDispatch {
   }
 
   onSubscriptionUpdate(subscription) {
-    if (this._endpoint) {
-      this._endpoint.send({
-        action: 'subscribe',
-        subscription: subscription,
-        userId: this._userId
-      });
-    }
-
     this.dispatchEvent(new PushClientEvent('subscriptionUpdate', {
       'subscription': subscription
     }));
@@ -143,9 +129,6 @@ export default class PushClient extends EventDispatch {
    *
    * If permission isn't granted for push, this method will show the
    * permissions dialog before attempting to subscribe the user to push.
-   *
-   * If an endpointUrl is supplied to the constructor, this will recieve
-   * a subscribe event.
    *
    * @return {Promise<PushSubscription>} A Promise that
    *  resolves with a PushSubscription if successful.
@@ -198,10 +181,6 @@ export default class PushClient extends EventDispatch {
   /**
    * This method will unsubscribe the user from push on the client side.
    *
-   * If you supplied an endpoint, this method will call it with an
-   * unsubscribe event, including the origin subscription object as well
-   * as the userId if supplied.
-   *
    * @return {Promise} A Promise that
    *  resolves once the user is unsubscribed.
    */
@@ -217,14 +196,13 @@ export default class PushClient extends EventDispatch {
       }
     }
 
-    if (this._endpoint) {
-      // POST subscription details
-      this._endpoint.send({
-        action: 'unsubscribe',
-        subscription: subscription,
-        userId: this._userId
-      });
-    }
+    this.dispatchEvent(new PushClientEvent('subscriptionUpdate', {
+      'subscription': null
+    }));
+
+    this.dispatchEvent(new PushClientEvent('stateChange', {
+      'state': PushClient.STATE_UNSUBSCRIBED
+    }));
   }
 
   /**

--- a/src/client/server-updater.js
+++ b/src/client/server-updater.js
@@ -12,18 +12,25 @@
 */
 /* eslint-env browser */
 
-export default class Endpoint {
-  constructor(url) {
-    this.url = url;
-  }
+export default function serverUpdater(url, user) {
+  return function(event) {
+    // We only really care about subscription changes
+    if (event.type === 'subscriptionUpdate') {
+      send(url, {
+        action: event.subscription ? 'subscribe' : 'unsubscribe'
+        subscription: event.subscription,
+        user: user
+      });
+    }
+  };
+}
 
-  send(message) {
-    return fetch(this.url, {
-      method: 'post',
-      body: JSON.stringify(message),
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    });
-  }
+function send(url, message) {
+  return fetch(url, {
+    method: 'post',
+    body: JSON.stringify(message),
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  });
 }


### PR DESCRIPTION
Make the endpoint code something optional that is available to developers instead.

You would use it like:

```javascript
var listener = goog.propel.serverUpdater(ENDPOINT_URL, myuser);
var client = new goog.propel.Client();

client.addEventListener(listener);
```

It's then easy to see how you could implement your own behaviour instead.

@owencm @ithinkihaveacat @gauntface