### PR TITLE
Shell script to manage version bump and release on NPM and Bower

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 npm-debug.log
 docs
+tagged-release

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,11 @@
+{
+  "name": "propel-web-push",
+  "description": "A library to support developers implementing Web Push notifications",
+  "license": "Apache-2.0",
+  "keywords": [
+    "web",
+    "push",
+    "propel"
+  ],
+  "homepage": "https://github.com/GoogleChrome/Propel"
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "propel",
-  "version": "1.0.0",
+  "name": "propel-web-push",
+  "version": "0.0.17",
   "description": "A library to support developers implementing Web Push notifications",
   "devDependencies": {
     "babel-eslint": "^6.0.0-beta.1",
@@ -29,17 +29,17 @@
     "rollup-plugin-commonjs": "^2.2.1",
     "rollup-plugin-node-resolve": "^1.5.0",
     "run-sequence": "^1.1.5",
+    "selenium-webdriver": "^2.52.0",
     "sinon": "^1.17.3",
     "vinyl-source-stream": "^1.1.0",
-    "which": "^1.2.4"
+    "which": "^1.2.4",
+    "pullr": "^0.3.2",
+    "selenium-webdriver": "^2.52.0"
   },
   "license": "Apache-2.0",
   "scripts": {
     "test": "gulp test:automated --throw-error",
     "build-docs": "esdoc -c esdoc.json",
     "publish-docs": "esdoc -c esdoc.json && git subtree push --prefix docs/ origin gh-pages"
-  },
-  "dependencies": {
-    "selenium-webdriver": "^2.52.0"
   }
 }

--- a/project/perform-release.sh
+++ b/project/perform-release.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+set -e
+
+# NOTES:
+#     To delete a tag use: git push origin :v1.0.0
+
+if [[ $1 != "patch" && $1 != "minor" && $1 != "major" ]] ; then
+  echo "    Bad input: Expected an update type of \"patch\", \"minor\" or \"major\"";
+  exit 1;
+fi
+
+echo ""
+echo "Sign into npm"
+echo ""
+npm whoami &>/dev/null || npm login
+
+echo ""
+echo "Building Library"
+echo ""
+gulp default --throw-error
+
+echo ""
+echo ""
+echo "Building Docs"
+echo ""
+esdoc -c esdoc.json
+
+echo ""
+echo ""
+echo "Update NPM Version"
+echo ""
+# We don't want to create a git tag against master branch. We want to tag
+# against the new directory 'tagged-release', but we do want package.json
+# in master to have the new version
+PACKAGE_VERSION=$(npm --no-git-tag-version version $1)
+
+echo ""
+echo ""
+echo "Are you sure you want to publish a new version of Propel [$PACKAGE_VERSION] y/N?"
+echo ""
+read answer
+if [[ $answer != "y" && $answer != "Y" ]]; then
+  # Revert the change to package.json
+  git checkout package.json
+  echo "    Not publishing the new release.";
+  exit 1;
+fi
+
+echo ""
+echo ""
+echo "Create and Copy Files for Release"
+echo ""
+# Remove any remaining artifacts from previous builds
+rm -rf ./tagged-release
+mkdir tagged-release
+
+# Copy over files that we want in the release
+cp -r ./docs ./tagged-release
+cp -r ./src ./tagged-release
+cp -r ./dist ./tagged-release
+cp LICENSE ./tagged-release
+cp package.json ./tagged-release
+cp bower.json ./tagged-release
+cp README.md ./tagged-release
+
+cd ./tagged-release/
+
+echo ""
+echo ""
+echo "Git push to release branch"
+echo ""
+GIT_REPO="https://github.com/GoogleChrome/Propel.git"
+git init
+git remote add origin $GIT_REPO
+git checkout -b release
+git add .
+git commit -m "New tagged release - $PACKAGE_VERSION"
+git tag -f $PACKAGE_VERSION
+git push -f origin release $PACKAGE_VERSION
+
+echo ""
+echo ""
+echo "Publish update to NPM"
+echo ""
+npm publish
+
+echo ""
+echo ""
+echo "Removing Tagged Release"
+echo ""
+cd ..
+rm -rf ./tagged-release
+
+echo ""
+echo ""
+echo "Generating a PR to update masters package.json"
+echo ""
+
+git add package.json
+git commit -m "Auto-generated PR to update package.json with new version - $PACKAGE_VERSION"
+git push -f origin release-pr
+
+./node_modules/pullr/bin/pullr.js --new --from release-pr --into master --title 'Auto-generated PR to update the version number' --description 'Please review this change and ensure that package.json is the ONLY file changed AND that the version matches the latest tagged release.'


### PR DESCRIPTION
@wibblymat @addyosmani @jeffposnick 

Hey all,

This is a script that will hopefully manage a clean push of Propel to NPM and bower. Idea is that only what we want makes it to the final release and no build artifacts are left in the master branch.

