### PR TITLE
Trying a new way to deploy gh-pages with a jekyll step on gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,5 +49,4 @@ before_script:
 
 script:
   - npm test
-  - npm run build-docs
-  - sh ./project/publish-docs.sh
+  - sh ./project/publish-docs.sh master/

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
   "license": "Apache-2.0",
   "scripts": {
     "test": "gulp test:automated --throw-error",
-    "build-docs": "esdoc -c esdoc.json",
-    "publish-docs": "esdoc -c esdoc.json && git subtree push --prefix docs/ origin gh-pages"
+    "build-docs": "esdoc -c esdoc.json"
   }
 }

--- a/project/perform-release.sh
+++ b/project/perform-release.sh
@@ -101,3 +101,9 @@ git commit -m "Auto-generated PR to update package.json with new version - $PACK
 git push -f origin release-pr
 
 ./node_modules/pullr/bin/pullr.js --new --from release-pr --into master --title 'Auto-generated PR to update the version number' --description 'Please review this change and ensure that package.json is the ONLY file changed AND that the version matches the latest tagged release.'
+
+echo ""
+echo ""
+echo "Build and Publish Docs"
+echo ""
+./project/publish-docs.sh releases/$PACKAGE_VERSION/

--- a/project/publish-docs.sh
+++ b/project/publish-docs.sh
@@ -1,27 +1,61 @@
-if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]
-then
-   echo "Deploying new docs to http://googlechrome.github.io/Propel/"
+#!/bin/bash
+set -e
 
-   # Helpful tips from Domenic https://gist.github.com/domenic/ec8b0fc8ab45f39403dd
-   # go to the docs directory and create a *new* Git repo
-   cd docs
-   git init
-
-   # inside this git repo we'll pretend to be a new user
-   git config user.name "Travis CI"
-   git config user.email "propel@google.com"
-
-   # The first and only commit to this new Git repo contains all the
-   # files present with the commit message "Deploy to GitHub Pages".
-   git add .
-   git commit -m "Deploy to GitHub Pages"
-
-   # Force push from the current repo's master branch to the remote
-   # repo's gh-pages branch. (All previous history on the gh-pages branch
-   # will be lost, since we are overwriting it.) We redirect any output to
-   # /dev/null to hide any sensitive credential data that might otherwise be exposed.
-   git push --force --quiet "https://${GH_TOKEN}@${GH_REF}" master:gh-pages > /dev/null 2>&1
-else
-   echo "Not a travis build of the master branch, not deploying"
-   # exit 0
+if [ -z "$1" ]; then
+  echo "    Bad input: Expected a directory as the first argument for the docs to go into (i.e. master/ or releases/v1.0.0/)";
+  exit 1;
 fi
+
+if [ "$TRAVIS" -a "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then
+  echo "In a travis build but not master branch so skipping doc deployment."
+  exit 0
+fi
+
+echo ""
+echo ""
+echo "Deploying new docs to http://googlechrome.github.io/Propel/$1"
+echo ""
+
+echo ""
+echo ""
+echo "Clone repo and get gh-pages branch"
+echo ""
+git clone https://github.com/GoogleChrome/Propel/ ./gh-pages
+cd ./gh-pages
+git checkout gh-pages
+cd ..
+
+echo ""
+echo ""
+echo "Build the docs"
+echo ""
+npm run build-docs
+
+
+echo ""
+echo ""
+echo "Copy docs to gh-pages"
+echo ""
+rm -rf ./gh-pages/$1
+mkdir -p ./gh-pages/$1
+cp -r ./docs/. ./gh-pages/$1
+
+
+echo ""
+echo ""
+echo "Commit to gh-pages"
+echo ""
+cd ./gh-pages
+
+# inside this git repo we'll pretend to be a new user
+git config user.name "Travis CI"
+git config user.email "propel@google.com"
+
+git add ./$1
+git commit -m "Deploy to GitHub Pages"
+
+# Force push from the current repo's master branch to the remote
+# repo's gh-pages branch. (All previous history on the gh-pages branch
+# will be lost, since we are overwriting it.) We redirect any output to
+# /dev/null to hide any sensitive credential data that might otherwise be exposed.
+git push --force --quiet "https://${GH_TOKEN}@${GH_REF}" gh-pages > /dev/null 2>&1


### PR DESCRIPTION
@addyosmani @wibblymat 

This is a change to the publish docs script that now puts the documents into a directory of master or releases on gh-pages that allows a very rough UI when you land on the docs pages.

It's an 'OK' first attempt to support this, but jekyll doesn't make it easy.