### PR TITLE
Change default scope

### DIFF
--- a/src/client/push-client.js
+++ b/src/client/push-client.js
@@ -19,7 +19,7 @@ import EventDispatch from './event-dispatch';
 // Set the default scope to be relative to the service worker
 // script with an addition string to prevent any unlikely collisions
 // This should allow multiple instances of push on the same scope to work
-const SCOPE = './goog.push.scope/';
+const DEFAULT_SCOPE = './';
 
 const SUPPORTED = 'serviceWorker' in navigator &&
     'PushManager' in window &&
@@ -99,7 +99,7 @@ export default class PushClient extends EventDispatch {
         this._scope = arguments[0].scope;
       } else if (typeof arguments[0] === 'string') {
         this._workerUrl = arguments[0];
-        this._scope = SCOPE;
+        this._scope = DEFAULT_SCOPE;
       }
     } else if (arguments.length === 2) {
       this._workerUrl = arguments[0];

--- a/src/client/push-client.js
+++ b/src/client/push-client.js
@@ -83,7 +83,7 @@ export default class PushClient extends EventDispatch {
     }
 
     if (workerUrlOrRegistration instanceof ServiceWorkerRegistration) {
-      this._registration = Promise.resolve(workerUrlOrRegistration);
+      this._registrationPromise = Promise.resolve(workerUrlOrRegistration);
     } else {
       const url = workerUrlOrRegistration;
       if (!url || typeof url !== 'string' || url.length === 0) {
@@ -94,7 +94,7 @@ export default class PushClient extends EventDispatch {
       if (scope) {
         options = {scope};
       }
-      this._registration = navigator.serviceWorker
+      this._registrationPromise = navigator.serviceWorker
         .register(workerUrlOrRegistration, options);
     }
 
@@ -146,7 +146,7 @@ export default class PushClient extends EventDispatch {
       this.dispatchEvent(new PushClientEvent('requestingsubscription'));
 
       // Make sure we have a service worker and subscribe for push
-      return this._registration;
+      return this._registrationPromise;
     })
     .then(registrationReady)
     .then(registration => {
@@ -197,7 +197,7 @@ export default class PushClient extends EventDispatch {
    *  resolves to either a ServiceWorkerRegistration or to null if none.
    */
   getRegistration() {
-    return this._registration;
+    return this._registrationPromise;
   }
 
   /**

--- a/src/client/push-client.js
+++ b/src/client/push-client.js
@@ -16,9 +16,6 @@ import SubscriptionFailedError from './subscription-failed-error';
 import PushClientEvent from './push-client-event';
 import EventDispatch from './event-dispatch';
 
-// Set the default scope to be relative to the service worker
-// script with an addition string to prevent any unlikely collisions
-// This should allow multiple instances of push on the same scope to work
 const DEFAULT_SCOPE = './';
 
 const SUPPORTED = 'serviceWorker' in navigator &&
@@ -122,6 +119,9 @@ export default class PushClient extends EventDispatch {
     if (!validInput) {
       throw new Error(ERROR_MESSAGES['bad constructor']);
     }
+
+    // Turn any relative scope into an absolute one, using the page URL as the base
+    this._scope = new URL(this._scope, window.location.href).href;
 
     // It is possible for the subscription to change in between page loads. We
     // should re-send the existing subscription when we initialise (if there is

--- a/src/client/push-client.js
+++ b/src/client/push-client.js
@@ -70,7 +70,7 @@ export default class PushClient extends EventDispatch {
    * obtained in the constructor and a subscriptionChange event will be
    * dispatched.
    *
-   * @param {String} workerUrl - Service worker URL to be
+   * @param {String} workerUrlOrRegistration - Service worker URL to be
    *  registered that will receive push events.
    * @param {String} scope - The scope that the Service worker should be
    *  registered with.
@@ -94,7 +94,8 @@ export default class PushClient extends EventDispatch {
       if (scope) {
         options = {scope};
       }
-      this._registration = navigator.serviceWorker.register(workerUrlOrRegistration, options);
+      this._registration = navigator.serviceWorker
+        .register(workerUrlOrRegistration, options);
     }
 
     // It is possible for the subscription to change in between page loads. We

--- a/src/client/push-client.js
+++ b/src/client/push-client.js
@@ -16,8 +16,6 @@ import SubscriptionFailedError from './subscription-failed-error';
 import PushClientEvent from './push-client-event';
 import EventDispatch from './event-dispatch';
 
-const DEFAULT_SCOPE = './';
-
 const SUPPORTED = 'serviceWorker' in navigator &&
     'PushManager' in window &&
     'Notification' in window &&
@@ -72,56 +70,32 @@ export default class PushClient extends EventDispatch {
    * obtained in the constructor and a subscriptionChange event will be
    * dispatched.
    *
-   * @param {Object} options - Options object should be included if you
-   *  want to define any of the following.
-   * @param {String} options.workerUrl - Service worker URL to be
+   * @param {String} workerUrl - Service worker URL to be
    *  registered that will receive push events.
-   * @param {String} options.scope - The scope that the Service worker should be
+   * @param {String} scope - The scope that the Service worker should be
    *  registered with.
    */
-  constructor() {
+  constructor(workerUrlOrRegistration, scope) {
     super();
 
     if (!PushClient.supported()) {
       throw new Error('Your browser does not support the web push API');
     }
 
-    // Initialise workerurl and scope from arguments
-    if (arguments.length === 1) {
-      if (arguments[0] instanceof ServiceWorkerRegistration) {
-        const serviceWorker = arguments[0].installing ||
-          arguments[0].waiting ||
-          arguments[0].active;
-        this._workerUrl = serviceWorker.scriptURL;
-        this._scope = arguments[0].scope;
-      } else if (typeof arguments[0] === 'string') {
-        this._workerUrl = arguments[0];
-        this._scope = DEFAULT_SCOPE;
+    if (workerUrlOrRegistration instanceof ServiceWorkerRegistration) {
+      this._registration = Promise.resolve(workerUrlOrRegistration);
+    } else {
+      const url = workerUrlOrRegistration;
+      if (!url || typeof url !== 'string' || url.length === 0) {
+        throw new Error(ERROR_MESSAGES['bad constructor']);
       }
-    } else if (arguments.length === 2) {
-      this._workerUrl = arguments[0];
-      this._scope = arguments[1];
+
+      let options;
+      if (scope) {
+        options = {scope};
+      }
+      this._registration = navigator.serviceWorker.register(workerUrlOrRegistration, options);
     }
-
-    // Ensure the worker url and scope are valid
-    const validInput = [this._workerUrl, this._scope].reduce(
-      (isValid, currentValue) => {
-        if (typeof currentValue === 'undefined' ||
-          currentValue === null ||
-          typeof currentValue !== 'string' ||
-          currentValue.length === 0) {
-          return false;
-        }
-
-        return isValid;
-      }, true);
-
-    if (!validInput) {
-      throw new Error(ERROR_MESSAGES['bad constructor']);
-    }
-
-    // Turn any relative scope into an absolute one, using the page URL as the base
-    this._scope = new URL(this._scope, window.location.href).href;
 
     // It is possible for the subscription to change in between page loads. We
     // should re-send the existing subscription when we initialise (if there is
@@ -171,9 +145,7 @@ export default class PushClient extends EventDispatch {
       this.dispatchEvent(new PushClientEvent('requestingsubscription'));
 
       // Make sure we have a service worker and subscribe for push
-      return navigator.serviceWorker.register(this._workerUrl, {
-        scope: this._scope
-      });
+      return this._registration;
     })
     .then(registrationReady)
     .then(registration => {
@@ -224,14 +196,7 @@ export default class PushClient extends EventDispatch {
    *  resolves to either a ServiceWorkerRegistration or to null if none.
    */
   getRegistration() {
-    return navigator.serviceWorker.getRegistration(this._scope)
-    .then(registration => {
-      if (registration && registration.scope === this._scope) {
-        return registration;
-      }
-
-      return null;
-    });
+    return this._registration;
   }
 
   /**

--- a/test/libs/state-stub.js
+++ b/test/libs/state-stub.js
@@ -35,7 +35,7 @@ class StateStub {
     // navigator.serviceWorker.register
     const registerStub = sinon.stub(
       navigator.serviceWorker, 'register', (swurl, options) => {
-        if (this.registration) {
+        if (this.registration && options && options.scope) {
           this.registration.scope = options.scope;
         }
         return Promise.resolve(this.registration);


### PR DESCRIPTION
Make the default scope be `./`, as it is for `navigator.serviceWorker.register`, to better reflect that we no longer assume you will have a separate push-only service worker.

@gauntface @ithinkihaveacat 