### PR TITLE
Improving tests and stubs to easier to reason with

### DIFF
--- a/src/client/push-client.js
+++ b/src/client/push-client.js
@@ -165,6 +165,11 @@ export default class PushClient extends EventDispatch {
       this._dispatchStatusUpdate();
 
       return subscription;
+    })
+    .catch(err => {
+      this._dispatchStatusUpdate();
+
+      throw err;
     });
   }
 

--- a/test/automated-suite.js
+++ b/test/automated-suite.js
@@ -63,6 +63,22 @@ describe('Test Propel', function() {
         const ffProfile = new seleniumFirefox.Profile();
         ffProfile.setPreference('security.turn_off_all_security_so_that_viruses_can_take_over_this_computer', true);
         browserInfo.seleniumOptions.setProfile(ffProfile);
+      } else if (browserInfo.seleniumBrowserId === 'chrome') {
+        /* eslint-disable camelcase */
+        const chromePreferences = {
+          profile: {
+            content_settings: {
+              exceptions: {
+                notifications: {}
+              }
+            }
+          }
+        };
+        chromePreferences.profile.content_settings.exceptions.notifications[testServerURL + ',*'] = {
+          setting: 1
+        };
+        browserInfo.seleniumOptions.setUserPreferences(chromePreferences);
+        /* eslint-enable camelcase */
       }
 
       globalDriverReference = browserInfo.getSeleniumDriver();

--- a/test/browser-tests/push-client/get-permission-state.js
+++ b/test/browser-tests/push-client/get-permission-state.js
@@ -43,7 +43,7 @@ describe('Test getPermissionState()', function() {
 
   it('should return permission status of granted', function() {
     stateStub = window.StateStub.getStub();
-    stateStub.setPermissionState('granted');
+    stateStub.stubNotificationPermissions('granted');
 
     return window.goog.propel.PropelClient.getPermissionState()
     .then(permissionState => {
@@ -53,7 +53,7 @@ describe('Test getPermissionState()', function() {
 
   it('should return permission status of default', function() {
     stateStub = window.StateStub.getStub();
-    stateStub.setPermissionState('default');
+    stateStub.stubNotificationPermissions('default');
 
     return window.goog.propel.PropelClient.getPermissionState()
     .then(permissionState => {
@@ -63,7 +63,7 @@ describe('Test getPermissionState()', function() {
 
   it('should return permission status of denied', function() {
     stateStub = window.StateStub.getStub();
-    stateStub.setPermissionState('denied');
+    stateStub.stubNotificationPermissions('denied');
 
     return window.goog.propel.PropelClient.getPermissionState()
     .then(permissionState => {

--- a/test/browser-tests/push-client/get-registration.js
+++ b/test/browser-tests/push-client/get-registration.js
@@ -58,7 +58,7 @@ describe('Test getRegistration()', function() {
 
   it('should resolve with a registration', function() {
     stateStub = window.StateStub.getStub();
-    stateStub.setUpRegistration(null);
+    stateStub.stubSWRegistration();
 
     const pushClient = new window.goog.propel.PropelClient(EMPTY_SW_PATH);
     return pushClient.getRegistration()

--- a/test/browser-tests/push-client/get-subscription.js
+++ b/test/browser-tests/push-client/get-subscription.js
@@ -49,7 +49,8 @@ describe('Test getSubscription()', function() {
 
   it('should return null when the user isn\'t subscribed', function() {
     stateStub = window.StateStub.getStub();
-    stateStub.setUpRegistration(null);
+    stateStub.stubSWRegistration();
+    stateStub.stubSubscription(null);
 
     const pushClient = new window.goog.propel.PropelClient(EMPTY_SW_PATH);
     return pushClient.getSubscription()
@@ -60,8 +61,9 @@ describe('Test getSubscription()', function() {
 
   it('should return a subscription when the user is subscribed', function() {
     stateStub = window.StateStub.getStub();
-    stateStub.setPermissionState('granted');
-    stateStub.setUpRegistration(EXAMPLE_SUBSCRIPTION);
+    stateStub.stubNotificationPermissions('granted');
+    stateStub.stubSWRegistration();
+    stateStub.stubSubscription(EXAMPLE_SUBSCRIPTION);
 
     // Subscribe before we initialise propel to see if it picks up the subscription
     return navigator.serviceWorker.register(EMPTY_SW_PATH)
@@ -79,8 +81,7 @@ describe('Test getSubscription()', function() {
 
   it('should manage a failing pushManager.getSubscription() call', function(done) {
     stateStub = window.StateStub.getStub(true);
-    // Empty function will caused an error to be throw
-    stateStub.setUpRegistration();
+    stateStub.stubSWRegistration();
 
     const pushClient = new window.goog.propel.PropelClient(EMPTY_SW_PATH);
     pushClient.getSubscription()

--- a/test/browser-tests/push-client/request-permission.js
+++ b/test/browser-tests/push-client/request-permission.js
@@ -45,8 +45,8 @@ describe('Test requestPermission()', function() {
   // We can't surpress a dialog after requesting it so force stub
   it('should dispatch a \'requestingpermission\' event when the permission state is default', function(done) {
     stateStub = window.StateStub.getStub(true);
-    stateStub.setPermissionState('default');
-    stateStub.setUpRegistration(null);
+    stateStub.stubNotificationPermissions('default');
+    stateStub.stubSWRegistration();
 
     const pushClient = new window.goog.propel.PropelClient(EMPTY_SW_PATH);
     pushClient.addEventListener('requestingpermission', () => {
@@ -58,8 +58,8 @@ describe('Test requestPermission()', function() {
   // We can't surpress a dialog after requesting it so force stub
   it('should resolve to default', function() {
     stateStub = window.StateStub.getStub(true);
-    stateStub.setPermissionState('default');
-    stateStub.setUpRegistration(null);
+    stateStub.stubNotificationPermissions('default');
+    stateStub.stubSWRegistration();
 
     const pushClient = new window.goog.propel.PropelClient(EMPTY_SW_PATH);
     return pushClient.requestPermission()
@@ -70,8 +70,8 @@ describe('Test requestPermission()', function() {
 
   it('should not dispatch a \'requestingpermission\' event because permission is granted', function(done) {
     stateStub = window.StateStub.getStub();
-    stateStub.setPermissionState('granted');
-    stateStub.setUpRegistration(null);
+    stateStub.stubNotificationPermissions('granted');
+    stateStub.stubSWRegistration();
 
     const pushClient = new window.goog.propel.PropelClient(EMPTY_SW_PATH);
     pushClient.addEventListener('requestingpermission', () => {
@@ -83,8 +83,8 @@ describe('Test requestPermission()', function() {
 
   it('should resolve to permission state of granted', function() {
     stateStub = window.StateStub.getStub();
-    stateStub.setPermissionState('granted');
-    stateStub.setUpRegistration(null);
+    stateStub.stubNotificationPermissions('granted');
+    stateStub.stubSWRegistration();
 
     const pushClient = new window.goog.propel.PropelClient(EMPTY_SW_PATH);
     return pushClient.requestPermission()
@@ -95,8 +95,8 @@ describe('Test requestPermission()', function() {
 
   it('should not dispatch a \'requestingpermission\' event because permission is blocked', function(done) {
     stateStub = window.StateStub.getStub();
-    stateStub.setPermissionState('denied');
-    stateStub.setUpRegistration(null);
+    stateStub.stubNotificationPermissions('denied');
+    stateStub.stubSWRegistration();
 
     const pushClient = new window.goog.propel.PropelClient(EMPTY_SW_PATH);
     pushClient.addEventListener('requestingpermission', () => {
@@ -108,8 +108,8 @@ describe('Test requestPermission()', function() {
 
   it('should resolve to blocked', function() {
     stateStub = window.StateStub.getStub();
-    stateStub.setPermissionState('denied');
-    stateStub.setUpRegistration(null);
+    stateStub.stubNotificationPermissions('denied');
+    stateStub.stubSWRegistration();
 
     const pushClient = new window.goog.propel.PropelClient(EMPTY_SW_PATH);
     pushClient.requestPermission()
@@ -120,8 +120,8 @@ describe('Test requestPermission()', function() {
 
   it('should dispatch a \'statuschange\' event when called directly', function(done) {
     stateStub = window.StateStub.getStub();
-    stateStub.setPermissionState('granted');
-    stateStub.setUpRegistration(null);
+    stateStub.stubNotificationPermissions('granted');
+    stateStub.stubSWRegistration();
 
     let counter = 0;
 

--- a/test/browser-tests/push-client/status-change-event.js
+++ b/test/browser-tests/push-client/status-change-event.js
@@ -48,8 +48,8 @@ describe('Test \'statuschange\' event', function() {
 
   it('should dispatch a \'statuschange\' event when the constructor is created (permission: default, subscription: null)', function(done) {
     stateStub = window.StateStub.getStub();
-    stateStub.setPermissionState('default');
-    stateStub.setUpRegistration(null);
+    stateStub.stubNotificationPermissions('default');
+    stateStub.stubSWRegistration();
 
     const pushClient = new window.goog.propel.PropelClient(EMPTY_SW_PATH);
     pushClient.addEventListener('statuschange', event => {
@@ -64,8 +64,8 @@ describe('Test \'statuschange\' event', function() {
 
   it('should dispatch a \'statuschange\' event when the constructor is created (permission: blocked, subscription: null)', function(done) {
     stateStub = window.StateStub.getStub();
-    stateStub.setPermissionState('denied');
-    stateStub.setUpRegistration(null);
+    stateStub.stubNotificationPermissions('denied');
+    stateStub.stubSWRegistration();
 
     const pushClient = new window.goog.propel.PropelClient(EMPTY_SW_PATH);
     pushClient.addEventListener('statuschange', event => {
@@ -80,8 +80,8 @@ describe('Test \'statuschange\' event', function() {
 
   it('should dispatch a \'statuschange\' event when the constructor is created (permission: granted, subscription: null)', function(done) {
     stateStub = window.StateStub.getStub();
-    stateStub.setPermissionState('granted');
-    stateStub.setUpRegistration(null);
+    stateStub.stubNotificationPermissions('granted');
+    stateStub.stubSWRegistration();
 
     const pushClient = new window.goog.propel.PropelClient(EMPTY_SW_PATH);
     pushClient.addEventListener('statuschange', event => {
@@ -96,8 +96,9 @@ describe('Test \'statuschange\' event', function() {
 
   it('should dispatch a \'statuschange\' event when the constructor is created (permission: granted, subscription: {STUBBED})', function(done) {
     stateStub = window.StateStub.getStub();
-    stateStub.setPermissionState('granted');
-    stateStub.setUpRegistration(EXAMPLE_SUBSCRIPTION);
+    stateStub.stubNotificationPermissions('granted');
+    stateStub.stubSWRegistration();
+    stateStub.stubSubscription(EXAMPLE_SUBSCRIPTION);
 
     // Subscribe before we initialise propel to see if it picks up the subscription
     return navigator.serviceWorker.register(EMPTY_SW_PATH)

--- a/test/browser-tests/push-client/subscribe.js
+++ b/test/browser-tests/push-client/subscribe.js
@@ -48,8 +48,8 @@ describe('Test subscribe()', function() {
 
   it('should return an error that the user dismissed the notification', function(done) {
     stateStub = window.StateStub.getStub(true);
-    stateStub.setPermissionState('default');
-    stateStub.setUpRegistration(null);
+    stateStub.stubNotificationPermissions('default');
+    stateStub.stubSWRegistration();
 
     const pushClient = new window.goog.propel.PropelClient(EMPTY_SW_PATH);
     pushClient.subscribe()
@@ -64,8 +64,8 @@ describe('Test subscribe()', function() {
 
   it('should dispatch a status event if the notification permission is blocked', function(done) {
     stateStub = window.StateStub.getStub();
-    stateStub.setPermissionState('denied');
-    stateStub.setUpRegistration(null);
+    stateStub.stubNotificationPermissions('denied');
+    stateStub.stubSWRegistration();
 
     let eventCounter = 0;
 
@@ -89,8 +89,8 @@ describe('Test subscribe()', function() {
 
   it('should reject the promise with an error that the user has blocked notifications', function(done) {
     stateStub = window.StateStub.getStub();
-    stateStub.setPermissionState('denied');
-    stateStub.setUpRegistration(null);
+    stateStub.stubNotificationPermissions('denied');
+    stateStub.stubSWRegistration();
 
     const pushClient = new window.goog.propel.PropelClient(EMPTY_SW_PATH);
     pushClient.subscribe()
@@ -105,8 +105,9 @@ describe('Test subscribe()', function() {
 
   it('should dispatch a status event with the subscription when the permission is granted', function(done) {
     stateStub = window.StateStub.getStub();
-    stateStub.setPermissionState('granted');
-    stateStub.setUpRegistration(EXAMPLE_SUBSCRIPTION);
+    stateStub.stubNotificationPermissions('granted');
+    stateStub.stubSWRegistration();
+    stateStub.stubSubscription(EXAMPLE_SUBSCRIPTION);
 
     let eventCounter = 0;
 
@@ -130,8 +131,9 @@ describe('Test subscribe()', function() {
 
   it('should resolve the promise with a subscription when notifications are granted', function(done) {
     stateStub = window.StateStub.getStub();
-    stateStub.setPermissionState('granted');
-    stateStub.setUpRegistration(EXAMPLE_SUBSCRIPTION);
+    stateStub.stubNotificationPermissions('granted');
+    stateStub.stubSWRegistration();
+    stateStub.stubSubscription(EXAMPLE_SUBSCRIPTION);
 
     const pushClient = new window.goog.propel.PropelClient(EMPTY_SW_PATH);
     pushClient.subscribe()
@@ -147,8 +149,9 @@ describe('Test subscribe()', function() {
 
   it('should dispath events in order, requestingpermission, requestingsubscription and statuschange', function(done) {
     stateStub = window.StateStub.getStub(true);
-    stateStub.setPermissionState('default');
-    stateStub.setUpRegistration(EXAMPLE_SUBSCRIPTION);
+    stateStub.stubNotificationPermissions('default');
+    stateStub.stubSWRegistration();
+    stateStub.stubSubscription(EXAMPLE_SUBSCRIPTION);
 
     let statuschangeCounter = 0;
     let eventTypes = [];
@@ -178,7 +181,7 @@ describe('Test subscribe()', function() {
       done();
     });
     pushClient.addEventListener('requestingpermission', event => {
-      stateStub.setPermissionState('granted');
+      stateStub.stubNotificationPermissions('granted');
 
       eventTypes.push(event.type);
     });

--- a/test/browser-tests/push-client/unsubscribe.js
+++ b/test/browser-tests/push-client/unsubscribe.js
@@ -49,8 +49,9 @@ describe('Test unsubscribe()', function() {
 
   it('should unsubscribe the current subscription', function() {
     stateStub = window.StateStub.getStub();
-    stateStub.setPermissionState('granted');
-    stateStub.setUpRegistration(EXAMPLE_SUBSCRIPTION);
+    stateStub.stubNotificationPermissions('granted');
+    stateStub.stubSWRegistration();
+    stateStub.stubSubscription(EXAMPLE_SUBSCRIPTION);
 
     // Subscribe before we initialise propel to see if it picks up the subscription
     return navigator.serviceWorker.register(EMPTY_SW_PATH)
@@ -67,8 +68,9 @@ describe('Test unsubscribe()', function() {
 
   it('should unsubscribe the current subscription and dispatch a statuschange event', function(done) {
     stateStub = window.StateStub.getStub();
-    stateStub.setPermissionState('granted');
-    stateStub.setUpRegistration(EXAMPLE_SUBSCRIPTION);
+    stateStub.stubNotificationPermissions('granted');
+    stateStub.stubSWRegistration();
+    stateStub.stubSubscription(EXAMPLE_SUBSCRIPTION);
 
     // Subscribe before we initialise propel to see if it picks up the subscription
     return navigator.serviceWorker.register(EMPTY_SW_PATH)
@@ -99,7 +101,7 @@ describe('Test unsubscribe()', function() {
 
   it('should reject promise when no registration is available', function(done) {
     stateStub = window.StateStub.getStub();
-    stateStub.setPermissionState('default');
+    stateStub.stubNotificationPermissions('default');
 
     const pushClient = new window.goog.propel.PropelClient(NON_EXISTANT_SW_PATH);
     pushClient.unsubscribe()
@@ -109,7 +111,7 @@ describe('Test unsubscribe()', function() {
 
   it('should dispatch a status event when no registration is available', function(done) {
     stateStub = window.StateStub.getStub();
-    stateStub.setPermissionState('default');
+    stateStub.stubNotificationPermissions('default');
 
     let statuschangeCounter = 0;
 
@@ -131,8 +133,9 @@ describe('Test unsubscribe()', function() {
 
   it('should resolve promise when no subscription is available', function() {
     stateStub = window.StateStub.getStub();
-    stateStub.setPermissionState('default');
-    stateStub.setUpRegistration(null);
+    stateStub.stubNotificationPermissions('default');
+    stateStub.stubSWRegistration();
+    stateStub.stubSubscription(null);
 
     const pushClient = new window.goog.propel.PropelClient(EMPTY_SW_PATH);
     return pushClient.unsubscribe();
@@ -140,8 +143,8 @@ describe('Test unsubscribe()', function() {
 
   it('should dispatch a status event when no subscription is available', function(done) {
     stateStub = window.StateStub.getStub();
-    stateStub.setPermissionState('default');
-    stateStub.setUpRegistration(null);
+    stateStub.stubNotificationPermissions('default');
+    stateStub.stubSWRegistration();
 
     let statuschangeCounter = 0;
 

--- a/test/browser-tests/push-worker/get-notifications/serviceworkers/default-get-notifications.js
+++ b/test/browser-tests/push-worker/get-notifications/serviceworkers/default-get-notifications.js
@@ -1,0 +1,51 @@
+/*
+  Copyright 2016 Google Inc. All Rights Reserved.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+'use strict';
+
+/* eslint-disable max-len, no-unused-expressions */
+/* eslint-env worker, serviceworker, mocha */
+
+importScripts('/test/libs/sw-mocha-runner.js');
+importScripts('/dist/propel-worker.js');
+
+const removeAllNotifications = () => {
+  return self.registration.getNotifications()
+  .then(notifications => {
+    return Promise.all(
+      notifications.map(notification => {
+        return notification.close();
+      })
+    );
+  });
+};
+
+self.setUpTests = () => {
+  describe('Test getNotifications() with \'default\' permission state', function() {
+    // Ensure we start with no notifications between tests
+    beforeEach(removeAllNotifications);
+    after(removeAllNotifications);
+
+    if (Notification.permission !== 'default') {
+      console.warn('Skipping default - getNotifications() tests due to no Notification permission');
+      return;
+    }
+
+    it('should resolve to an array regardless of permission state', function() {
+      return self.goog.propel.worker.helpers.getNotifications()
+      .then(notifications => {
+        (notifications instanceof Array).should.equal(true);
+      });
+    });
+  });
+};

--- a/test/browser-tests/push-worker/get-notifications/serviceworkers/denied-get-notifications.js
+++ b/test/browser-tests/push-worker/get-notifications/serviceworkers/denied-get-notifications.js
@@ -1,0 +1,51 @@
+/*
+  Copyright 2016 Google Inc. All Rights Reserved.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+'use strict';
+
+/* eslint-disable max-len, no-unused-expressions */
+/* eslint-env worker, serviceworker, mocha */
+
+importScripts('/test/libs/sw-mocha-runner.js');
+importScripts('/dist/propel-worker.js');
+
+const removeAllNotifications = () => {
+  return self.registration.getNotifications()
+  .then(notifications => {
+    return Promise.all(
+      notifications.map(notification => {
+        return notification.close();
+      })
+    );
+  });
+};
+
+self.setUpTests = () => {
+  describe('Test getNotifications() with \'denied\' permission state', function() {
+    // Ensure we start with no notifications between tests
+    beforeEach(removeAllNotifications);
+    after(removeAllNotifications);
+
+    if (Notification.permission !== 'denied') {
+      console.warn('Skipping denied - getNotifications() tests due to no Notification permission');
+      return;
+    }
+
+    it('should resolve to an array regardless of permission state', function() {
+      return self.goog.propel.worker.helpers.getNotifications()
+      .then(notifications => {
+        (notifications instanceof Array).should.equal(true);
+      });
+    });
+  });
+};

--- a/test/browser-tests/push-worker/get-notifications/serviceworkers/granted-get-notifications.js
+++ b/test/browser-tests/push-worker/get-notifications/serviceworkers/granted-get-notifications.js
@@ -31,7 +31,7 @@ const removeAllNotifications = () => {
 };
 
 self.setUpTests = () => {
-  describe('Test getNotifications()', function() {
+  describe('Test getNotifications() with \'granted\' permission state', function() {
     // Ensure we start with no notifications between tests
     beforeEach(removeAllNotifications);
     after(removeAllNotifications);

--- a/test/libs/stubs/base-stub.js
+++ b/test/libs/stubs/base-stub.js
@@ -18,24 +18,25 @@
 
 /* eslint-env browser */
 
-const DEFAULT_PERMISSION_STATE = 'default';
-
 class BaseStateStub {
   constructor() {
-    this.setPermissionState(DEFAULT_PERMISSION_STATE);
-    this._currentRegistration = null;
+    this.ERROR_REGISTRATION = 0;
   }
 
   restore() {
     throw new Error('restore() must be overriden');
   }
 
-  setPermissionState() {
-    throw new Error('setPermissionState() must be overriden');
+  stubNotificationPermissions() {
+    throw new Error('stubNotificationPermissions() must be overriden');
   }
 
-  setUpRegistration() {
-    throw new Error('setUpRegistration() must be overriden');
+  stubSWRegistration() {
+    throw new Error('stubSWRegistration() must be overriden');
+  }
+
+  stubSubscription() {
+    throw new Error('stubSubscription() must be overriden');
   }
 }
 

--- a/test/libs/stubs/firefox-stub.js
+++ b/test/libs/stubs/firefox-stub.js
@@ -38,7 +38,7 @@ class FFStateStub extends window.BaseStateStub {
       Services.perms.PROMPT_ACTION);
   }
 
-  setPermissionState(newState) {
+  stubNotificationPermissions(newState) {
     let permissionState;
     switch (newState) {
       case 'granted':
@@ -66,8 +66,12 @@ class FFStateStub extends window.BaseStateStub {
       permissionState);
   }
 
-  setUpRegistration() {
+  stubSWRegistration() {
     // NOOP - We use actual SW registration etc
+  }
+
+  stubSubscription() {
+    // NOOP - We use actual push manage subscriptions etc
   }
 }
 

--- a/test/libs/sw-mocha-runner.js
+++ b/test/libs/sw-mocha-runner.js
@@ -20,8 +20,10 @@ importScripts('/node_modules/chai/chai.js');
 
 const getFriendlyTestResult = testResult => {
   return {
+    parentTitle: testResult.parent.title,
     title: testResult.title,
-    state: testResult.state
+    state: testResult.state,
+    err: testResult.err
   };
 };
 


### PR DESCRIPTION
@addyosmani @jeffposnick @wibblymat 

There are a few minor fixes, but this PR largely improves the stubs for the tests (I was getting a little worried about unpredictable side effects of the stubs) + improves error messages from SW -> Page for failed tests.

This also encourages use of manipulating the permissions before running the propel-worker.getNotifications() tests.

* This also adds in support for setting chrome's notification permission before starting the browser, although at the moment it's hard coded to always grant permissions. I need to explore ways of setting the permissions to allow / deny etc depending on the tests.